### PR TITLE
Fix array enumerator

### DIFF
--- a/src/JsonEasyNavigation.Tests/ArrayTests.cs
+++ b/src/JsonEasyNavigation.Tests/ArrayTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using Shouldly;
 using Xunit;
@@ -123,5 +124,21 @@ namespace JsonEasyNavigation.Tests
 
             nav.Keys.ShouldBeEmpty();
         }
-    }
+
+		[Fact]
+		public void EnumerateArray_ShouldEnumerateItems()
+        {
+			var json = @"[ ""item1"", ""item2"", ""item3"" ]";
+
+			var jsonDocument = JsonDocument.Parse(json);
+			var nav = jsonDocument.ToNavigation();
+            
+            var list = new List<string>();
+            foreach (var item in nav)
+            {
+                list.Add(item.GetStringOrEmpty());
+            }
+            list.ShouldBe(new[] { "item1", "item2", "item3" });
+		}
+	}
 }

--- a/src/JsonEasyNavigation.Tests/PropertyTests.cs
+++ b/src/JsonEasyNavigation.Tests/PropertyTests.cs
@@ -270,5 +270,37 @@ namespace JsonEasyNavigation.Tests
             var item = nav["item1"]["item3"]; 
             item.Exist.ShouldBeFalse();
         }
+
+        [Fact]
+        public void EnumerateObject_ShouldEnumerateProperties()
+        {
+            var json = @"{ ""item1"" : ""first"", ""item2"": ""second"" }";
+
+            var jsonDocument = JsonDocument.Parse(json);
+            var nav = jsonDocument.ToNavigation();
+
+            var list = new List<string>();
+            foreach (var item in nav)
+            {
+                list.Add(item.Name);
+            }
+            list.ShouldBe(new[] { "item1", "item2" });
+        }
+
+        [Fact]
+        public void EnumerateObject_CachedProperties_ShouldEnumerateProperties()
+        {
+            var json = @"{ ""item1"" : ""first"", ""item2"": ""second"" }";
+
+            var jsonDocument = JsonDocument.Parse(json);
+            var nav = jsonDocument.ToNavigation().WithCachedProperties();
+
+            var list = new List<string>();
+            foreach (var item in nav)
+            {
+                list.Add(item.Name);
+            }
+            list.ShouldBe(new[] { "item1", "item2" });
+        }
     }
 }

--- a/src/JsonEasyNavigation/ArrayEnumeratorWrapper.cs
+++ b/src/JsonEasyNavigation/ArrayEnumeratorWrapper.cs
@@ -5,9 +5,9 @@ using System.Text.Json;
 
 namespace JsonEasyNavigation
 {
-    internal readonly struct ArrayEnumeratorWrapper : IEnumerator<JsonNavigationElement>
+    internal struct ArrayEnumeratorWrapper : IEnumerator<JsonNavigationElement>
     {
-        private readonly JsonElement.ArrayEnumerator _enumerator;
+        private JsonElement.ArrayEnumerator _enumerator;
         
         public ArrayEnumeratorWrapper(JsonElement jsonElement)
         {

--- a/src/JsonEasyNavigation/JsonEasyNavigation.csproj
+++ b/src/JsonEasyNavigation/JsonEasyNavigation.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-        <Version>1.2.0</Version>
+        <Version>1.3.0</Version>
         <PackageIcon>logo.png</PackageIcon>
         <Title>JsonEasyNavigation</Title>
         <Authors>Sharkadi Andrey</Authors>


### PR DESCRIPTION
Fixes #7 

* Remove `readonly` from `ArrayEnumeratorWrapper` to allow it to move between elements.
* Add tests for array and object enumerators.
* Updated version number.

